### PR TITLE
Switch to option-based configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,16 @@ Without arguments `bin/run` will connect to `localhost:15672` with the default g
 
 ### Configuration
 
-| Setting | Environment variable | Effect | Default |
-| ------- | -------------------- | ------ | ------- |
-| Show entities | `SHOW_ENTITIES` | Toggles displaying entities in the generated graph. | `'true'` |
-| Label details | `LABEL_DETAIL` | Comma separated segment names to display on labels drawn between applications and/or entities. | `'actions'` |
-| RabbitMQ management URL | `RABBITMQ_API_URI` | Specifies the connection URL to RabbitMQ management API | `http://guest:guest@localhost:15672/` |
+| Setting | Configuration | Effect | Default |
+| ------- | ------------- | ------ | ------- |
+| RabbitMQ management URL | `-uURL`<br/>`--url=URL`<br/>or environment variable<br/>`RABBITMQ_API_URI` | Specifies the connection URL to RabbitMQ management API | http://guest:guest@localhost:15672/ |
+| Show only applications | `-a`<br/>`--applications-only` | Creates a graph without entity nodes. | disabled |
+| Label details | `-lDETAILS`<br/>`--label-detail=DETAILS` | Comma separated segment names to display on labels drawn between applications and/or entities. | `'actions'` |
 
-### Show entities
+### Show only applications
 
-- **false**: will only show application to application relations.
-- **true**: will show application to entity to application relations. The edge going into the entity and coming out of the entity will have the same label.
+- **enabled**: will only show application to application relations.
+- **disabled** (default): will show application to entity to application relations. The edge going into the entity and coming out of the entity will have the same label.
 
 ### Label details
 

--- a/bin/run
+++ b/bin/run
@@ -4,11 +4,44 @@
 require 'bundler/setup'
 $LOAD_PATH.unshift(Bundler.root) unless $LOAD_PATH.include?(Bundler.root)
 
+require 'optparse'
 require 'app/discover'
 require 'app/dot_format'
 
-topology = Discover.new.topology
+options = {
+  discover: {
+    api_url: ENV['RABBITMQ_API_URI'] || 'http://guest:guest@localhost:15672/'
+  },
+  format: {
+    show_entities: ENV['SHOW_ENTITIES'] == 'true' || true,
+    label_detail: ENV['LABEL_DETAIL'] || 'actions'
+  }
+}
+OptionParser.new do |opts|
+  opts.banner = "Usage: #{__FILE__} [options]"
 
-show_entities = ENV.fetch('SHOW_ENTITIES', 'true') == 'true'
-label_detail = ENV.fetch('LABEL_DETAIL', 'actions').to_s.split(',').map(&:strip).reject(&:empty?).map(&:to_sym)
-puts DotFormat.new(topology: topology, show_entities: show_entities, label_detail: label_detail).present
+  opts.on('-uURL', '--url=URL', 'RabbitMQ management API URL. ' \
+          'Defaults to "http://guest:guest@localhost:15672/". ' \
+          'Also configurable through the "RABBITMQ_API_URI" environment variable.') do |url|
+    options[:discover][:api_url] = url
+  end
+  opts.on('-a', '--applications-only', 'Creates a graph without entity nodes.') do |apps_only|
+    options[:format][:show_entities] = !apps_only
+  end
+  opts.on('-lDETAILS', '--label-detail=DETAILS', 'Specifies edge label format. ' \
+          'Comma separated list of "queue_name", "entity", "actions"') do |label_detail|
+    options[:format][:label_detail] = label_detail.to_s
+  end
+  opts.on('-h', '--help', 'Prints this help.') do
+    puts opts
+    exit
+  end
+end.parse!
+
+topology = Discover.new(api_url: options[:discover][:api_url]).topology
+label_detail = options[:format][:label_detail].split(',').map(&:strip).reject(&:empty?).map(&:to_sym)
+puts DotFormat.new(
+  topology: topology,
+  show_entities: options[:format][:show_entities],
+  label_detail: label_detail
+).present


### PR DESCRIPTION
`SHOW_ENTITIES` and `LABEL_DETAIL` are formatter related arguments and contain no secrets.

It makes more sense to pass these in as command line options, so this is what this changeset does.