### PR TITLE
Add reading and saving topology files

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Without arguments `bin/run` will connect to `localhost:15672` with the default g
 | RabbitMQ management URL | `-uURL`<br/>`--url=URL`<br/>or environment variable<br/>`RABBITMQ_API_URI` | Specifies the connection URL to RabbitMQ management API | http://guest:guest@localhost:15672/ |
 | Show only applications | `-a`<br/>`--applications-only` | Creates a graph without entity nodes. | disabled |
 | Label details | `-lDETAILS`<br/>`--label-detail=DETAILS` | Comma separated segment names to display on labels drawn between applications and/or entities. | `'actions'` |
+| Save topology | `--save-topology=FILE` | After discovery save the topology to the given file. | disabled |
+| Read topology | `--read-topology=FILE` | Skip discovery and use a stored topology file. | disabled |
 
 ### Show only applications
 

--- a/bin/run
+++ b/bin/run
@@ -4,11 +4,13 @@
 require 'bundler/setup'
 $LOAD_PATH.unshift(Bundler.root) unless $LOAD_PATH.include?(Bundler.root)
 
+require 'json'
 require 'optparse'
 require 'app/discover'
 require 'app/dot_format'
 
 options = {
+  topology: {},
   discover: {
     api_url: ENV['RABBITMQ_API_URI'] || 'http://guest:guest@localhost:15672/'
   },
@@ -32,13 +34,29 @@ OptionParser.new do |opts|
           'Comma separated list of "queue_name", "entity", "actions"') do |label_detail|
     options[:format][:label_detail] = label_detail.to_s
   end
+  opts.on('--read-topology=FILE', 'Skip discovery and use a stored topology file.') do |file|
+    options[:topology][:read_file] = file
+  end
+  opts.on('--save-topology=FILE', 'After discovery save the topology to the given file.') do |file|
+    options[:topology][:save_file] = file
+  end
   opts.on('-h', '--help', 'Prints this help.') do
     puts opts
     exit
   end
 end.parse!
 
-topology = Discover.new(api_url: options[:discover][:api_url]).topology
+topology = if (read_file = options[:topology][:read_file])
+             JSON.parse(IO.read(read_file), symbolize_names: true).map { |route_hash| Route.new(route_hash) }
+           else
+             result = Discover.new(api_url: options[:discover][:api_url]).topology
+             if (save_file = options[:topology][:save_file])
+               output = "[\n  " + result.map { |e| JSON.generate(e.to_h) }.join(",\n  ") + "\n]\n"
+               IO.write(save_file, output)
+             end
+             result
+           end
+
 label_detail = options[:format][:label_detail].split(',').map(&:strip).reject(&:empty?).map(&:to_sym)
 puts DotFormat.new(
   topology: topology,


### PR DESCRIPTION
The ability to save and reuse discovery results allows us to generate different views and archive the topology without querying multiple times.