### PR TITLE
Add markdown table format

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,16 @@ Without arguments `bin/run` will connect to `localhost:15672` with the default g
 | Setting | Configuration | Effect | Default |
 | ------- | ------------- | ------ | ------- |
 | RabbitMQ management URL | `-uURL`<br/>`--url=URL`<br/>or environment variable<br/>`RABBITMQ_API_URI` | Specifies the connection URL to RabbitMQ management API | http://guest:guest@localhost:15672/ |
-| Show only applications | `-a`<br/>`--applications-only` | Creates a graph without entity nodes. | disabled |
-| Label details | `-lDETAILS`<br/>`--label-detail=DETAILS` | Comma separated segment names to display on labels drawn between applications and/or entities. | `'actions'` |
 | Save topology | `--save-topology=FILE` | After discovery save the topology to the given file. | disabled |
 | Read topology | `--read-topology=FILE` | Skip discovery and use a stored topology file. | disabled |
+| Choose format | `--format=FORMAT` | Choose an output format. `--help` will give a list of available options. | `DotFormat` |
+
+#### Dot format specific options
+
+| Setting | Configuration | Effect | Default |
+| ------- | ------------- | ------ | ------- |
+| Show only applications | `--dot-applications-only` | Creates a graph without entity nodes. | disabled |
+| Label details | `--dot-label-detail=DETAILS` | Comma separated segment names to display on labels drawn between applications and/or entities. | `'actions'` |
 
 ### Show only applications
 

--- a/app/markdown_table_format.rb
+++ b/app/markdown_table_format.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Presents a RabbitMQ topology in a GitHub-flavoured Markdown table
+class MarkdownTableFormat
+  def initialize(topology:)
+    @topology = topology
+  end
+
+  def present
+    no_consumer_routes = topology.select(&:missing_target?)
+    no_binding_routes = topology.select(&:missing_source?)
+    default_tag_routes = topology.select(&:default_consumer_tag?)
+    connected_routes = topology.reject { |r| r.missing_source? || r.missing_target? || r.default_consumer_tag? }
+
+    lines = []
+    lines.concat(route_table('Routes without consumers', no_consumer_routes))
+    lines.concat(route_table('Routes without publisher bindings', no_binding_routes))
+    lines.concat(route_table('Routes with default consumer names', default_tag_routes))
+    lines.concat(route_table('Named, connected routes', connected_routes))
+    lines.join("\n")
+  end
+
+  private
+
+  attr_reader :topology
+
+  def route_table(title, routes)
+    return [] if routes.empty?
+    lines = []
+    lines << ''
+    lines << "# #{title}"
+    lines << ''
+    lines << '| Publisher application | Consumer application | Entity | Actions | Queue |'
+    lines << '| --- | --- | --- | --- | --- |'
+    lines.concat(routes.map { |route| route_line(route) }.uniq)
+  end
+
+  def route_line(route)
+    columns = []
+    columns << route.source_app
+    columns << route.target_app
+    columns << route.entity
+    columns << route.actions.join('.')
+    columns << route.queue_name
+    '| ' + columns.join(' | ') + ' |'
+  end
+end

--- a/app/route.rb
+++ b/app/route.rb
@@ -2,9 +2,9 @@
 
 # Extracts publisher/consumer application names and routing key fragments from routing data
 class Route
-  DEFAULT_CONSUMER_TAG = '<default-consumer-tag>'
-  MISSING_SOURCE_LABEL = '<no-routing-key-binding>'
-  MISSING_TARGET_LABEL = '<no-consumers>'
+  DEFAULT_CONSUMER_TAG = 'default-consumer-tag'
+  MISSING_SOURCE_LABEL = 'no-routing-key-binding'
+  MISSING_TARGET_LABEL = 'no-consumers'
 
   def initialize(queue_name:, routing_key: nil, consumer_tag: nil)
     @queue_name = queue_name

--- a/bin/run
+++ b/bin/run
@@ -8,58 +8,70 @@ require 'json'
 require 'optparse'
 require 'app/discover'
 require 'app/dot_format'
+require 'app/markdown_table_format'
 
-options = {
-  topology: {},
-  discover: {
-    api_url: ENV['RABBITMQ_API_URI'] || 'http://guest:guest@localhost:15672/'
-  },
-  format: {
-    show_entities: ENV['SHOW_ENTITIES'] == 'true' || true,
-    label_detail: ENV['LABEL_DETAIL'] || 'actions'
-  }
-}
-OptionParser.new do |opts|
-  opts.banner = "Usage: #{__FILE__} [options]"
+def topology(options)
+  if (read_file = options[:discover][:read_topology_file])
+    JSON.parse(IO.read(read_file), symbolize_names: true).map { |route_hash| Route.new(route_hash) }
+  else
+    result = Discover.new(api_url: options[:discover][:api_url]).topology
+    if (save_file = options[:discover][:save_topology_file])
+      output = "[\n  " + result.map { |e| JSON.generate(e.to_h) }.join(",\n  ") + "\n]\n"
+      IO.write(save_file, output)
+    end
+    result
+  end
+end
 
-  opts.on('-uURL', '--url=URL', 'RabbitMQ management API URL. ' \
-          'Defaults to "http://guest:guest@localhost:15672/". ' \
-          'Also configurable through the "RABBITMQ_API_URI" environment variable.') do |url|
+def setup_discovery_options(options, option_parser)
+  options[:discover] ||= {}
+  options[:discover][:api_url] = ENV['RABBITMQ_API_URI'] || 'http://guest:guest@localhost:15672/'
+  option_parser.on('-uURL', '--url=URL', 'RabbitMQ management API URL. ' \
+                   'Defaults to "http://guest:guest@localhost:15672/". ' \
+                   'Also configurable through the "RABBITMQ_API_URI" environment variable.') do |url|
     options[:discover][:api_url] = url
   end
-  opts.on('-a', '--applications-only', 'Creates a graph without entity nodes.') do |apps_only|
-    options[:format][:show_entities] = !apps_only
+  option_parser.on('--read-topology=FILE', 'Skip discovery and use a stored topology file.') do |file|
+    options[:discover][:read_topology_file] = file
   end
-  opts.on('-lDETAILS', '--label-detail=DETAILS', 'Specifies edge label format. ' \
-          'Comma separated list of "queue_name", "entity", "actions"') do |label_detail|
-    options[:format][:label_detail] = label_detail.to_s
+  option_parser.on('--save-topology=FILE', 'After discovery save the topology to the given file.') do |file|
+    options[:discover][:save_topology_file] = file
   end
-  opts.on('--read-topology=FILE', 'Skip discovery and use a stored topology file.') do |file|
-    options[:topology][:read_file] = file
+end
+
+def setup_format_options(options, option_parser, formats:)
+  options[:format] = formats.first
+  option_parser.on('--format=FORMAT', formats.map(&:to_s), "Select format to use from #{formats.join(', ')}. " \
+                   "Defaults to #{options[:format]}.") do |format|
+    options[:format] = Object.const_get(format)
   end
-  opts.on('--save-topology=FILE', 'After discovery save the topology to the given file.') do |file|
-    options[:topology][:save_file] = file
+
+  formats.each { |format| options[format] = {} }
+
+  # DotFormat specific options
+  options[DotFormat][:show_entities] = true
+  option_parser.on('--dot-applications-only', 'Creates a graph without entity nodes.') do |apps_only|
+    options[DotFormat][:show_entities] = !apps_only
   end
-  opts.on('-h', '--help', 'Prints this help.') do
-    puts opts
+
+  options[DotFormat][:label_detail] = %i[actions]
+  option_parser.on('--dot-label-detail=DETAILS', 'Specifies edge label format. ' \
+                   'Comma separated list of "queue_name", "entity", "actions"') do |label_detail|
+    options[DotFormat][:label_detail] = label_detail.to_s.split(',').map(&:strip).reject(&:empty?).map(&:to_sym)
+  end
+end
+
+options = {}
+OptionParser.new do |option_parser|
+  option_parser.banner = "Usage: #{__FILE__} [options]"
+  setup_discovery_options(options, option_parser)
+  setup_format_options(options, option_parser, formats: [DotFormat, MarkdownTableFormat])
+  option_parser.on('-h', '--help', 'Prints this help.') do
+    puts option_parser
     exit
   end
 end.parse!
 
-topology = if (read_file = options[:topology][:read_file])
-             JSON.parse(IO.read(read_file), symbolize_names: true).map { |route_hash| Route.new(route_hash) }
-           else
-             result = Discover.new(api_url: options[:discover][:api_url]).topology
-             if (save_file = options[:topology][:save_file])
-               output = "[\n  " + result.map { |e| JSON.generate(e.to_h) }.join(",\n  ") + "\n]\n"
-               IO.write(save_file, output)
-             end
-             result
-           end
-
-label_detail = options[:format][:label_detail].split(',').map(&:strip).reject(&:empty?).map(&:to_sym)
-puts DotFormat.new(
-  topology: topology,
-  show_entities: options[:format][:show_entities],
-  label_detail: label_detail
-).present
+chosen_format = options[:format]
+format_options = options[chosen_format].merge(topology: topology(options))
+puts chosen_format.new(format_options).present

--- a/spec/app/dot_format_spec.rb
+++ b/spec/app/dot_format_spec.rb
@@ -9,17 +9,6 @@ RSpec.describe DotFormat do
     let(:show_entities) { true }
     let(:label_detail) { %i[actions] }
 
-    def route(data, missing_source: false, missing_target: false, default_consumer_tag: false)
-      stubs = {
-        missing_source?: missing_source,
-        missing_target?: missing_target,
-        default_consumer_tag?: default_consumer_tag,
-        entity: '',
-        actions: []
-      }.merge(data)
-      instance_double(Route, stubs)
-    end
-
     let(:topology) do
       [route(source_app: 'from', target_app: 'to', entity: 'thing', actions: %w[happened]),
        route(source_app: 'from', target_app: 'another', entity: 'clowns', actions: %w[coming fast])]

--- a/spec/app/markdown_table_format_spec.rb
+++ b/spec/app/markdown_table_format_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'app/markdown_table_format'
+require 'app/route'
+
+RSpec.describe MarkdownTableFormat do
+  let(:topology) { [] }
+  subject(:present) { described_class.new(topology: topology).present }
+
+  it 'shows routes without consumers as a separate section' do
+    topology << route(queue_name: 'no_consumer_queue', source_app: 'connected_part', target_app: 'none',
+                      entity: 'entity', actions: %w[action], missing_target?: true)
+
+    expect(present).to include(
+      <<~TABLE.strip
+        # Routes without consumers
+
+        | Publisher application | Consumer application | Entity | Actions | Queue |
+        | --- | --- | --- | --- | --- |
+        | connected_part | none | entity | action | no_consumer_queue |
+      TABLE
+    )
+  end
+
+  it 'shows routes without bindings as a separate section' do
+    topology << route(queue_name: 'no_binding_queue', source_app: 'none', target_app: 'connected_part',
+                      missing_source?: true)
+
+    expect(present).to include(
+      <<~TABLE.strip
+        # Routes without publisher bindings
+
+        | Publisher application | Consumer application | Entity | Actions | Queue |
+        | --- | --- | --- | --- | --- |
+        | none | connected_part |  |  | no_binding_queue |
+      TABLE
+    )
+  end
+
+  it 'shows routes with default consumer tags as a separate section' do
+    topology << route(queue_name: 'default_tag_queue', source_app: 'connected_part', target_app: 'unknown',
+                      entity: 'entity', actions: %w[action], default_consumer_tag?: true)
+
+    expect(present).to include(
+      <<~TABLE.strip
+        # Routes with default consumer names
+
+        | Publisher application | Consumer application | Entity | Actions | Queue |
+        | --- | --- | --- | --- | --- |
+        | connected_part | unknown | entity | action | default_tag_queue |
+      TABLE
+    )
+  end
+
+  it 'shows connected routes as a separate section' do
+    topology << route(queue_name: 'q1', source_app: 'from', target_app: 'to', entity: 'entity', actions: %w[action])
+    topology << route(queue_name: 'q2', source_app: 'from', target_app: 'to', entity: 'fire', actions: %w[get out])
+
+    expect(present).to include(
+      <<~TABLE.strip
+        # Named, connected routes
+
+        | Publisher application | Consumer application | Entity | Actions | Queue |
+        | --- | --- | --- | --- | --- |
+        | from | to | entity | action | q1 |
+        | from | to | fire | get.out | q2 |
+      TABLE
+    )
+  end
+end

--- a/spec/app/route_spec.rb
+++ b/spec/app/route_spec.rb
@@ -24,31 +24,31 @@ RSpec.describe Route do
   it 'marks a route without a routing key as a route missing a source' do
     route = Route.new(queue_name: 'test', routing_key: nil, consumer_tag: 'something_defined')
     expect(route.missing_source?).to eq(true)
-    expect(route.source_app).to eq('<no-routing-key-binding>')
+    expect(route.source_app).to eq('no-routing-key-binding')
   end
 
   it 'marks a route without a consumer tag as a route without a target' do
     route = Route.new(queue_name: 'test', routing_key: 'something_defined', consumer_tag: nil)
     expect(route.missing_target?).to eq(true)
-    expect(route.target_app).to eq('<no-consumers>')
+    expect(route.target_app).to eq('no-consumers')
   end
 
   it 'marks a route with a "bunny" consumer tag prefix as a route with a default consumer tag' do
     route = Route.new(queue_name: 'test', consumer_tag: 'bunny-123-123')
     expect(route.default_consumer_tag?).to eq(true)
-    expect(route.target_app).to eq('<default-consumer-tag>')
+    expect(route.target_app).to eq('default-consumer-tag')
   end
 
   it 'marks a route with a "hutch" consumer tag prefix as a route with a default consumer tag' do
     route = Route.new(queue_name: 'test', consumer_tag: 'hutch-123-123')
     expect(route.default_consumer_tag?).to eq(true)
-    expect(route.target_app).to eq('<default-consumer-tag>')
+    expect(route.target_app).to eq('default-consumer-tag')
   end
 
   it 'marks a route with an "amq.ctag" consumer tag prefix as a route with a default consumer tag' do
     route = Route.new(queue_name: 'test', consumer_tag: 'amq.ctag-123-123')
     expect(route.default_consumer_tag?).to eq(true)
-    expect(route.target_app).to eq('<default-consumer-tag>')
+    expect(route.target_app).to eq('default-consumer-tag')
   end
 
   it 'marks a route with other consumer tags as a route with a custom consumer tag' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,3 +8,8 @@ SimpleCov.start do
   add_filter '/spec/'
   add_filter '/vendor/'
 end
+
+require 'support/route_helper'
+RSpec.configure do |c|
+  c.include RouteHelper
+end

--- a/spec/support/route_helper.rb
+++ b/spec/support/route_helper.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'app/route'
+
+module RouteHelper
+  def route(data)
+    defaults = {
+      missing_source?: false,
+      missing_target?: false,
+      default_consumer_tag?: false,
+      entity: '',
+      actions: [],
+      source_app: nil,
+      target_app: nil
+    }
+    instance_double(Route, defaults.merge(data))
+  end
+end


### PR DESCRIPTION
Adds a new (GitHub-flavoured) markdown table formatter.

Invoked as `bin/run --format=MarkdownTableFormat`.

### Why
The dot format is useful for visual inspection. The table format can be used for searching a particular entity or application, so it can be used as generated documentation.

### Additional changes

**Remove brackets from special application names**
Since we will have more than one formatter, each of those should decide if they want special formatting attached to the default names. The formatters can decide via the `missing_source?`, `missing_target?` and `default_consumer_tag?` predicates.