### PR TITLE
Remove Gemnasium badge from the readme

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rabbitmq-graph (0.1.0)
+    rabbitmq-graph (0.1.1)
       hutch (~> 0.24)
       ruby-progressbar (~> 1.9)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # rabbitmq-graph
 
-[![Dependency Status](https://gemnasium.com/badges/github.com/sldblog/rabbitmq-graph.svg)](https://gemnasium.com/github.com/sldblog/rabbitmq-graph)
 [![CircleCI](https://circleci.com/gh/sldblog/rabbitmq-graph.svg?style=svg&circle-token=68531f42debaa4ff5b3bddb62a4672ca2eaabaf4)](https://circleci.com/gh/sldblog/rabbitmq-graph)
 [![Maintainability](https://api.codeclimate.com/v1/badges/146dab10c24b4dd7b75e/maintainability)](https://codeclimate.com/github/sldblog/rabbitmq-graph/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/146dab10c24b4dd7b75e/test_coverage)](https://codeclimate.com/github/sldblog/rabbitmq-graph/test_coverage)


### PR DESCRIPTION
As the project already integrates with Dependabot, there seems to be no immediate need to revive the service.

**Bonus**: Update Gemfile.lock which was missed at v0.1.1